### PR TITLE
Make whole card a link, not just image for team page

### DIFF
--- a/team.css
+++ b/team.css
@@ -1,42 +1,51 @@
-.team-member-container {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    max-width: 1000px;
-    flex-basis: 21%;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.team-member-card {
-    margin: 10px 5px;
-    border-radius: 10px;
-    border-style: solid;
-    border-width: 1px;
-    border-color: #ccc;
-    overflow: hidden;
-    box-shadow: 0px 5px 10px #00000009;
-    background-color: #fff;
-    max-width: 200px;
-    text-decoration: none;
-    color: black;
-}
-
-.team-member-photo {
-    max-width: 200px;
+@@ -27,6 +27,7 @@
 }
 
 .team-member-name {
+    text-decoration: none;
     font-weight: 600;
     margin: 0px;
     margin-left: 12px;
-}
-
-.team-member-roles {
-    font-weight: 300;
-    margin: 0px;
+@@ -38,5 +39,17 @@
     margin-left: 12px;
     margin-bottom: 6px;
     font-size: 15px;
+    text-decoration: none !important;
 }
 
+/* Remove blue underlines from links within .team-member-card */
+.team-member-card a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  /* Remove blue underlines for link hover state (optional) */
+  .team-member-card a:hover {
+    text-decoration: none;
+  }
+
+  2 changes: 1 addition & 1 deletion2  
+team.html
+@@ -51,4 +51,4 @@ <h2>Alumni</h2>
+
+    <script src="footer.js"></script>
+  </body>
+</html>
+</html>
+ 
+@@ -464,13 +464,11 @@ var cards = {
+
+cards.forEach((member) =>
+  document.write(
+    `<div class="team-member-card">
+      ${member["link"] ? `<a href="${member.link}" target="_blank" rel="noopener">` : ""}
+    `<a href="${member.link || 'javascript:void(0)'}" target="_blank" rel="noopener" class="team-member-card"> 
+      <img width=200px height=200px class="team-member-photo" src="images/members/${member.image}">
+      ${(member["link"] ? `</a>` : "")}
+      <p class="team-member-name">${member.name}</p>
+      <p class="team-member-roles">${member.roles}</p>
+    </div>
+    `
+    </a>`
+  )
+);


### PR DESCRIPTION
Team page member cards should be like those for sponsors and pages on the landing page (index.html) instead of what currently happens, where only the image goes to the member's link.
Solution: To make the entire card a link while keeping the layout the same, you have to wrap the entire card div in an anchor (<a>) element.
